### PR TITLE
Adding support for Swagger tags

### DIFF
--- a/core/src/main/scala/io/fintrospect/RouteSpec.scala
+++ b/core/src/main/scala/io/fintrospect/RouteSpec.scala
@@ -15,7 +15,8 @@ case class RouteSpec private(summary: String,
                              consumes: Set[ContentType],
                              body: Option[Body[_]],
                              requestParams: Seq[QueryOrHeader[_]],
-                             responses: Seq[ResponseSpec]) {
+                             responses: Seq[ResponseSpec],
+                             tags: Seq[TagInfo]) {
 
   private[fintrospect] def <--?(request: Request): Extraction[Request] = {
     val contents = Map[Any, Extraction[_]]((requestParams ++ body).map(r => (r, r <--? request)): _*)
@@ -67,6 +68,16 @@ case class RouteSpec private(summary: String,
     */
   def returning(code: (Status, String), example: String): RouteSpec = copy(responses = new ResponseSpec(code, Option(example)) +: responses)
 
+  /**
+    * Add tags to this routes. Provides the ability to group routes by tag in a generated schema.
+    */
+  def taggedWith(tag: String): RouteSpec = copy(tags = tags :+ TagInfo(tag))
+
+  /**
+    * Add tags to this routes. Provides the ability to group routes by tag in a generated schema.
+    */
+  def taggedWith(tags: TagInfo*): RouteSpec = copy(tags = this.tags ++ tags)
+
   def at(method: Method) = UnboundRoute(this, method)
 }
 
@@ -74,5 +85,5 @@ object RouteSpec {
   type QueryOrHeader[T] = HasParameters with Extractor[Request, _] with Rebindable[Request, _, Binding]
 
   def apply(summary: String = "<unknown>", description: String = null): RouteSpec =
-    RouteSpec(summary, Option(description), Set.empty, Set.empty, None, Nil, Nil)
+    RouteSpec(summary, Option(description), Set.empty, Set.empty, None, Nil, Nil, Nil)
 }

--- a/core/src/main/scala/io/fintrospect/TagInfo.scala
+++ b/core/src/main/scala/io/fintrospect/TagInfo.scala
@@ -1,0 +1,11 @@
+package io.fintrospect
+
+/**
+  * Info about a Swagger tag.
+  */
+case class TagInfo(name: String, description: Option[String] = None)
+
+object TagInfo {
+  def apply(name: String, description: String): TagInfo =
+    TagInfo(name, Some(description))
+}

--- a/core/src/test/resources/io/fintrospect/renderers/swagger2dot0/Swagger2dot0JsonTest.json
+++ b/core/src/test/resources/io/fintrospect/renderers/swagger2dot0/Swagger2dot0JsonTest.json
@@ -6,6 +6,15 @@
     "description": "module description"
   },
   "basePath": "/",
+  "tags": [
+    {
+      "name": "tag1"
+    },
+    {
+      "name": "tag2",
+      "description": "description of tag"
+    }
+  ],
   "paths": {
     "/basepath/welcome/{firstName}/bertrand/{secondName}": {
       "get": {
@@ -60,7 +69,7 @@
     "/basepath/echo/{message}": {
       "post": {
         "tags": [
-          "/basepath"
+          "tag2"
         ],
         "summary": "a post endpoint",
         "description": null,
@@ -116,7 +125,7 @@
       },
       "get": {
         "tags": [
-          "/basepath"
+          "tag1"
         ],
         "summary": "summary of this route",
         "description": "some rambling description of what this thing actually does",


### PR DESCRIPTION
This addresses #41.

The tag info summary at the top of the Swagger file is generated automatically from the tags present in the routes. This avoids duplication of tag definitions, but at the price that it's not possible to explicitly order the tags in the output. It's possible to fix this, but that would add some more clutter. Not sure yet whether it's worth it.