### PR TITLE
Remove duplicate Swagger tags from the rendered JSON

### DIFF
--- a/core/src/main/scala/io/fintrospect/renderers/swagger2dot0/Swagger2dot0Json.scala
+++ b/core/src/main/scala/io/fintrospect/renderers/swagger2dot0/Swagger2dot0Json.scala
@@ -112,7 +112,11 @@ case class Swagger2dot0Json(apiInfo: ApiInfo) extends ModuleRenderer {
     }
   }
 
-  private def fetchTags(routes: Seq[ServerRoute[_, _]]) = routes.flatMap(_.routeSpec.tags).sortBy(_.name)
+  private def fetchTags(routes: Seq[ServerRoute[_, _]]) =
+    routes
+      .flatMap(_.routeSpec.tags)
+      .distinct
+      .sortBy(_.name)
 
   override def description(basePath: Path, security: Security, routes: Seq[ServerRoute[_, _]]): Response = {
     val pathsAndDefinitions = routes

--- a/core/src/test/resources/io/fintrospect/renderers/swagger2dot0/Swagger2dot0JsonTest.json
+++ b/core/src/test/resources/io/fintrospect/renderers/swagger2dot0/Swagger2dot0JsonTest.json
@@ -72,6 +72,7 @@
     "/basepath/echo/{message}": {
       "post": {
         "tags": [
+          "tag1",
           "tag2"
         ],
         "summary": "a post endpoint",

--- a/core/src/test/scala/io/fintrospect/renderers/ArgoJsonModuleRendererTest.scala
+++ b/core/src/test/scala/io/fintrospect/renderers/ArgoJsonModuleRendererTest.scala
@@ -44,6 +44,7 @@ abstract class ArgoJsonModuleRendererTest() extends FunSpec with Matchers {
             .returning(ResponseSpec.json(Status.Forbidden -> "no way jose", obj("aString" -> Argo.JsonFormat.string("a message of some kind"))))
             .taking(Query.required.int("query"))
             .body(customBody)
+            .taggedWith("tag1")
             .taggedWith(TagInfo("tag2", "description of tag"), TagInfo("tag2", "description of tag"))
             .at(Post) / "echo" / Path.string("message") bindTo ((s: String) => Echo(s)))
         .withRoute(


### PR DESCRIPTION
Flatmapping over a `Seq` with a `Set` yields a `Seq`, and so we have duplicates in the resulting JSON.
This pull request solves this issue.